### PR TITLE
Using the --cask tag

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -107,3 +107,7 @@ export LANG=en_US.UTF-8
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# Jenv - to initialize switching between jvm’s
+export PATH="$HOME/.jenv/bin:$PATH"
+eval "$(jenv init -)"

--- a/bootstrap.exclude.sh
+++ b/bootstrap.exclude.sh
@@ -69,6 +69,17 @@ oh_my_zsh() {
     fi
 }
 
+jenv() {
+    echo "${BLUE}Install jenv?${NC} (y/n)"
+    read resp
+    if [ "$resp" = 'y' -o "$resp" = 'Y' ] ; then
+        echo "installing jenv"
+        sh jenv.exclude.sh
+    else
+        echo "skipping jenv"
+    fi
+}
+
 
 init
 link
@@ -77,4 +88,4 @@ compile_exports
 set_zsh
 oh_my_zsh
 link
-
+jenv

--- a/brew.exclude.sh
+++ b/brew.exclude.sh
@@ -36,17 +36,17 @@ brew install gh
 brew install helm
 
 # Cask
-brew cask install docker
-brew cask install slack
-brew cask install google-chrome
-brew cask install discord
+brew install docker --cask
+brew install slack --cask
+brew install google-chrome --cask
+brew install discord --cask
 
 # Java
 brew tap AdoptOpenJDK/openjdk
-brew cask install adoptopenjdk/openjdk/adoptopenjdk8
-brew cask install adoptopenjdk/openjdk/adoptopenjdk11
-brew cask install adoptopenjdk/openjdk/adoptopenjdk12
-brew cask install adoptopenjdk/openjdk/adoptopenjdk14
+brew install adoptopenjdk/openjdk/adoptopenjdk8 --cask 
+brew install adoptopenjdk/openjdk/adoptopenjdk11 --cask 
+brew install adoptopenjdk/openjdk/adoptopenjdk12 --cask 
+brew install adoptopenjdk/openjdk/adoptopenjdk14 --cask
 
 # Jetty
 brew install jetty
@@ -56,7 +56,7 @@ brew install maven
 brew install maven-completion
 
 # iTerm2
-brew cask install iterm2
+brew install iterm2 --cask
 
 # zsh
 brew install zsh

--- a/jenv.exclude.sh
+++ b/jenv.exclude.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Jenv - auto switching between jvms (https://www.jenv.be/)
+
+# Setup jenv
+brew install jenv
+
+echo "Adding adoptopenjdk 8 to jenv"
+jenv add /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+
+echo "Adding adoptopenjdk 11 to jenv"
+jenv add /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
+
+echo "Adding adoptopenjdk 12 to jenv"
+jenv add /Library/Java/JavaVirtualMachines/adoptopenjdk-12.jdk/Contents/Home
+
+# This could be made generic by having the user select from a list of "jenv versions"
+echo "Setting global java version to 1.8.0.222"
+jenv global 1.8.0.275
+
+echo "Enable maven plugin that makes jenv take control of java version for maven"
+jenv sh-enable-plugin maven
+echo "Enable export plugin that makes jenv take control of java version for JAVA_HOME"
+jenv sh-enable-plugin export
+
+echo "Calling the jenv doctor to make sure everything is all right"
+jenv doctor
+echo "Note that 'No JAVA_HOME set' is OK as the export plugin requires a new session to take effect"

--- a/srv-adm-jetty.exclude.sh
+++ b/srv-adm-jetty.exclude.sh
@@ -5,5 +5,7 @@ export app=LOCAL
 export logstashDestination=LOGSTASH_DESTINATION 
 export JETTY_BASE=`pwd`
 export JAVA_OPTIONS="-Xmx2g -Dspring.profiles.active=adcm,default"
- 
+export JAVA="$JAVA_HOME/bin/java" # Based on using jenv
+
+
 sh $JETTY_SH $1 JAVA=$JAVA JAVA_OPTIONS=$JAVA_OPTIONS JETTY_HOME=$JETTY_HOME JETTY_BASE=$JETTY_BASE JETTY_RUN=$JETTY_BASE


### PR DESCRIPTION
`brew cask <command>` was deprecated in favor of `brew <command> --cask` in Homebrew 2.6.0.