### PR TITLE
Clean up Brewfile and brew setup

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -25,4 +25,4 @@ alias 🦉='git add .'
 alias 🍰='git commit -m '
 
 # Exa
-alias e='exa --icons --git -laTL 1'
+alias e='eza --icons --git -laTL 1'

--- a/Brewfile
+++ b/Brewfile
@@ -1,51 +1,69 @@
-# Tap
-tap 'homebrew/cask'
-tap 'homebrew/cask-fonts'
-tap 'homebrew/cask-versions'
+# Taps
+tap 'azure/kubelogin'
+tap 'hashicorp/tap'
+tap 'mvndaemon/mvnd'
+tap 'nais/tap'
 
-# Div
+# Core tools
 brew 'coreutils'
-brew 'bash-completion'
 brew 'git'
-brew 'bash-git-prompt'
-brew 'z'
-brew 'speedtest-cli'
 brew 'gh'
-brew 'cask'
-brew 'zsh'
-brew 'zsh-syntax-highlighting'
-brew 'maven'
-brew 'maven-completion'
-brew 'cheat'
 brew 'vim'
 brew 'wget'
-brew 'helm'
-brew 'python'
-brew 'brew-pip'
-brew 'node'
-brew 'npm'
-brew 'exa'
-brew 'kubeseal'
-brew 'thefuck'
+
+# Shell
+brew 'bash-completion'
+brew 'bash-git-prompt'
+brew 'zsh'
+brew 'zsh-syntax-highlighting'
 brew 'fish'
 brew 'starship'
-brew 'kubernetes-cli'
-brew 'mkdocs'
-brew 'mvndaemon/homebrew-mvnd/mvnd'
-brew 'kubectx'
+brew 'z'
+brew 'thefuck'
+
+# Development
+brew 'node'
+brew 'python@3.14'
+brew 'maven'
+brew 'maven-completion'
 brew 'gradle'
+brew 'mvndaemon/mvnd/mvnd'
 brew 'gemini-cli'
 
+# Kubernetes / Cloud
+brew 'kubernetes-cli'
+brew 'kubectx'
+brew 'kubeseal'
+brew 'helm'
+brew 'azure-cli'
+brew 'azure/kubelogin/kubelogin'
+brew 'hashicorp/tap/vault'
+brew 'cloudflared'
+brew 'nais/tap/nais'
+
+# Utilities
+brew 'eza'
+brew 'cheat'
+brew 'speedtest-cli'
+brew 'mkdocs'
+
 # Casks
+cask 'ghostty'
 cask 'iterm2'
+cask 'visual-studio-code'
+cask 'copilot-cli'
+cask 'docker-desktop'
 cask 'keystore-explorer'
+cask 'alfred'
+cask 'discord'
+cask 'nais/tap/naisdevice'
+
+# Fonts
 cask 'font-jetbrains-mono'
 cask 'font-jetbrains-mono-nerd-font'
-cask 'visual-studio-code'
 
-# Temurin Java
+# Java (Temurin)
 cask 'temurin'
-cask 'temurin21'
-cask 'temurin17'
-cask 'temurin8'
-cask 'temurin11'
+cask 'temurin@25'
+cask 'temurin@21'
+cask 'temurin@17'

--- a/brew-install.sh
+++ b/brew-install.sh
@@ -6,7 +6,7 @@
 which brew 1>&/dev/null
 if [ ! "$?" -eq 0 ] ; then
 	echo "Homebrew not installed. Attempting to install Homebrew"
-	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	if [ ! "$?" -eq 0 ] ; then
 		echo "Something went wrong. Exiting..." && exit 1
 	fi
@@ -19,4 +19,4 @@ brew update
 brew upgrade
 
 # Brewfile
-brew bundle
+brew bundle --no-lock

--- a/config/fish/alias.fish
+++ b/config/fish/alias.fish
@@ -1,5 +1,5 @@
 # Aliases
-alias e='exa --icons --git -laTL 1'
+alias e='eza --icons --git -laTL 1'
 alias googlecloud='gcloud auth login'
 
 # Maven


### PR DESCRIPTION
- Remove deprecated taps (homebrew/cask, cask-fonts, cask-versions)
- Remove deprecated formulae (exa, brew-pip, npm, cask)
- Replace exa with eza in Brewfile and aliases
- Pin python to python@3.14
- Add missing installed formulae/casks (azure-cli, cloudflared, kubelogin,
  vault, nais, ghostty, copilot-cli, docker-desktop, alfred, discord)
- Add required taps (azure/kubelogin, hashicorp/tap, nais/tap)
- Drop EOL Temurin versions (Java 8, 11)
- Modernize brew-install.sh installer URL
- Use brew bundle --no-lock
- Reorganize Brewfile into logical sections

Closes #7

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
